### PR TITLE
[graphql]: supports defer/stream

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1430,6 +1430,11 @@
       "integrity": "sha512-f66KywYG6+43afgE/8j/GoiNyygk/bnoCbps++3ErRKsIYkGGupyv07R2Ok5m9i67Iqc+T2g1eAUGUPzWhYTyg==",
       "dev": true
     },
+    "node_modules/piecemeal": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/piecemeal/-/piecemeal-0.1.0.tgz",
+      "integrity": "sha512-i8fZam/clglfJMF7q9fj3ahfdw5IV4M/1qSVZmR3vWST0XRPO68/39fVO9MRssWHtzs3NfpyHT1hYYiLcQTrzw=="
+    },
     "node_modules/qs": {
       "version": "6.10.3",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
@@ -1755,7 +1760,7 @@
     },
     "packages/cloudflare-access": {
       "name": "@cloudflare/pages-plugin-cloudflare-access",
-      "version": "0.1.1",
+      "version": "1.0.0",
       "dependencies": {
         "jsrsasign": "^10.5.17"
       },
@@ -1765,7 +1770,7 @@
     },
     "packages/google-chat": {
       "name": "@cloudflare/pages-plugin-google-chat",
-      "version": "0.1.3",
+      "version": "1.0.0",
       "dependencies": {
         "jsrsasign": "^10.5.17"
       },
@@ -1776,14 +1781,17 @@
     },
     "packages/graphql": {
       "name": "@cloudflare/pages-plugin-graphql",
-      "version": "0.1.1",
+      "version": "1.0.0",
+      "dependencies": {
+        "piecemeal": "^0.1.0"
+      },
       "devDependencies": {
         "graphql": "^16.3.0"
       }
     },
     "packages/hcaptcha": {
       "name": "@cloudflare/pages-plugin-hcaptcha",
-      "version": "0.1.0"
+      "version": "1.0.0"
     },
     "packages/headers": {
       "name": "@cloudflare/pages-plugin-headers",
@@ -1791,7 +1799,7 @@
     },
     "packages/honeycomb": {
       "name": "@cloudflare/pages-plugin-honeycomb",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "dependencies": {
         "@cloudflare/workers-honeycomb-logger": "^2.1.0"
       }
@@ -1802,7 +1810,7 @@
     },
     "packages/sentry": {
       "name": "@cloudflare/pages-plugin-sentry",
-      "version": "0.1.1",
+      "version": "1.0.0",
       "dependencies": {
         "toucan-js": "^2.6.0"
       }
@@ -1814,11 +1822,11 @@
     },
     "packages/static-forms": {
       "name": "@cloudflare/pages-plugin-static-forms",
-      "version": "0.1.0"
+      "version": "1.0.0"
     },
     "packages/stytch": {
       "name": "@cloudflare/pages-plugin-stytch",
-      "version": "0.1.1",
+      "version": "1.0.0",
       "dependencies": {
         "cookie": "^0.5.0"
       }
@@ -1843,7 +1851,8 @@
     "@cloudflare/pages-plugin-graphql": {
       "version": "file:packages/graphql",
       "requires": {
-        "graphql": "^16.3.0"
+        "graphql": "^16.3.0",
+        "piecemeal": "^0.1.0"
       }
     },
     "@cloudflare/pages-plugin-hcaptcha": {
@@ -2831,6 +2840,11 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.0.tgz",
       "integrity": "sha512-f66KywYG6+43afgE/8j/GoiNyygk/bnoCbps++3ErRKsIYkGGupyv07R2Ok5m9i67Iqc+T2g1eAUGUPzWhYTyg==",
       "dev": true
+    },
+    "piecemeal": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/piecemeal/-/piecemeal-0.1.0.tgz",
+      "integrity": "sha512-i8fZam/clglfJMF7q9fj3ahfdw5IV4M/1qSVZmR3vWST0XRPO68/39fVO9MRssWHtzs3NfpyHT1hYYiLcQTrzw=="
     },
     "qs": {
       "version": "6.10.3",

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -12,6 +12,9 @@
   "scripts": {
     "build": "npx wrangler pages functions build --plugin --outfile index.js"
   },
+  "dependencies": {
+		"piecemeal": "^0.1.0"
+  },
   "devDependencies": {
     "graphql": "^16.3.0"
   }


### PR DESCRIPTION
This PR allows the graphql plugin to support the defer/stream spec. Inspiration taken from 

https://github.com/maraisr/graphql-workers/blob/b58bc4eece886df474432c00f49fb90ef00e83f7/src/index.ts#L40-L52

---

if the user knows they need defer/stream — they'll also know to resolve `graphql@16.1.0-experimental-stream-defer.6` for this.