### PR TITLE
[graphql]: supports sending in context values

### DIFF
--- a/packages/graphql/functions/index.ts
+++ b/packages/graphql/functions/index.ts
@@ -24,10 +24,10 @@ export const onRequestPost: GraphQLPagesPluginFunction = async ({
   request,
   pluginArgs,
 }) => {
-  const { schema, graphql } = pluginArgs;
+  const { graphql, ...rest } = pluginArgs;
 
   const result = await graphql({
-    schema,
+    ...rest,
     ...(await extractGraphQLQueryFromRequest(request)),
   });
 

--- a/packages/graphql/index.d.ts
+++ b/packages/graphql/index.d.ts
@@ -1,5 +1,5 @@
-import type { graphql, GraphQLSchema } from "graphql";
+import type { graphql, GraphQLArgs } from "graphql";
 
-export type PluginArgs = { schema: GraphQLSchema; graphql: typeof graphql };
+export type PluginArgs = { graphql: typeof graphql } & GraphQLArgs;
 
 export default function (args: PluginArgs): PagesFunction;


### PR DESCRIPTION
most graphql servers make use of the context property when setting up the server. This could be for example to include the colo, or the Request object itself for resolvers to use.

Lets let the plugin supply the entire constructor's arguments. 