### PR TITLE
chore: Improve conversion from string to char array

### DIFF
--- a/.changeset/empty-oranges-sparkle.md
+++ b/.changeset/empty-oranges-sparkle.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/pages-plugin-cloudflare-access": patch
+---
+
+chore: Improve conversion from string to char array
+
+This code was a bit hard to read and got typescript errors when copying to a Workers project. This improves the speed by 1.8X and makes the code easier to understand.

--- a/packages/cloudflare-access/functions/_middleware.ts
+++ b/packages/cloudflare-access/functions/_middleware.ts
@@ -17,7 +17,7 @@ const extractJWTFromRequest = (request: Request) =>
 const base64URLDecode = (s: string) => {
   s = s.replace(/-/g, "+").replace(/_/g, "/").replace(/\s/g, "");
   return new Uint8Array(
-    Array.prototype.map.call(atob(s), (c: string) => c.charCodeAt(0)),
+    Array.from(atob(s)).map((c: string) => c.charCodeAt(0)),
   );
 };
 


### PR DESCRIPTION
I was copying the Access plugin to a Worker and came across a TypeScript issue with this string to char array conversion.
This improves the speed by 1.8X and makes the code easier to understand (I was confused at first by what this code was trying to accomplish.)

jsbench showing it's faster: https://jsbench.me/sblbw7en4w
The speed difference doesn't matter, but I wanted to ensure that the change didn't drastically slow it down.

[Playground link](https://www.typescriptlang.org/play?#code/MYewdgzgLgBBMF4YHICGAJASgBmOgsgGwAyAngJykBaAGgEISo0CKArgJoBM5Ux2dAR3YB1AHIgRAVgDWwCgFEqwgGKkAysIAeEACY1RuALYAbAG57RAEQBGnbSIBSp4IeXYmVY8G6Gd6HQAWLgCqAFaowjK0AOasqGD4CMgAsABQoJCwmogwYACmAO4wwQCWYFAAHACCAE41qKQAFGkwrbX1pAB0AGY1IIaNqFAg1o0QAJTjnYaoAA6NjcAAXHBQNWXR44gAfDDAncABqDUAwiA6eVVQjdiTaeNpaRnQMKQ5+UWl5dV1Dc2pAEh2g1OrM+sMoKRZnlpnMDqhjMZBsNRhMADQwRZbBC7faHY5nC5XG53VIPVJPcAQEDGGHGEDRRqacnPGl0hmNUgsqlszr0xmaTrDNRrDaNbEIJBdYWisCMyYwAD0ipga1YeSAA) showing that the output is the same, as well as the TypeScript error I'm getting. I'm guessing this error started happening in a newer TS version?