### PR TITLE
Upgrade wrangler to v2.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@changesets/cli": "^2.25.2",
         "@cloudflare/workers-types": "^4.20221111.1",
         "typescript": "^4.9.3",
-        "wrangler": "^2.6.1"
+        "wrangler": "^2.8.0"
       }
     },
     "example": {
@@ -481,13 +481,13 @@
       }
     },
     "node_modules/@miniflare/cache": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.10.0.tgz",
-      "integrity": "sha512-nzEqFVPnD7Yf0HMDv7gCPpf4NSXfjhc+zg3gSwUS4Dad5bWV10B1ujTZW6HxQulW3CBHIg616mTjXIiaimVuEQ==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.11.0.tgz",
+      "integrity": "sha512-L/kc9AzidPwFuk2fwHpAEePi0kNBk6FWUq3ln+9beRCDrPEpfVrDRFpNleF1NFZz5//oeVMuo8F0IVUQGzR7+Q==",
       "dev": true,
       "dependencies": {
-        "@miniflare/core": "2.10.0",
-        "@miniflare/shared": "2.10.0",
+        "@miniflare/core": "2.11.0",
+        "@miniflare/shared": "2.11.0",
         "http-cache-semantics": "^4.1.0",
         "undici": "5.9.1"
       },
@@ -496,12 +496,12 @@
       }
     },
     "node_modules/@miniflare/cli-parser": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.10.0.tgz",
-      "integrity": "sha512-NAiCtqlHTUKCmV+Jl9af+ixGmMhiGhIyIfr/vCdbismNEBxEsrQGg3sQYTNfvCkdHtODurQqayQreFq21OuEow==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.11.0.tgz",
+      "integrity": "sha512-JUmyRzEGAS6CouvXJwBh8p44onfw3KRpfq5JGXEuHModOGjTp6li7PQyCTNPV2Hv/7StAXWnTFGXeAqyDHuTig==",
       "dev": true,
       "dependencies": {
-        "@miniflare/shared": "2.10.0",
+        "@miniflare/shared": "2.11.0",
         "kleur": "^4.1.4"
       },
       "engines": {
@@ -509,15 +509,15 @@
       }
     },
     "node_modules/@miniflare/core": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.10.0.tgz",
-      "integrity": "sha512-Jx1M5oXQua0jzsJVdZSq07baVRmGC/6JkglrPQGAlZ7gQ1sunVZzq9fjxFqj0bqfEuYS0Wy6+lvK4rOAHISIjw==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.11.0.tgz",
+      "integrity": "sha512-UFMFiCG0co36VpZkgFrSBnrxo71uf1x+cjlzzJi3khmMyDlnLu4RuIQsAqvKbYom6fi3G9Q8lTgM7JuOXFyjhw==",
       "dev": true,
       "dependencies": {
         "@iarna/toml": "^2.2.5",
-        "@miniflare/queues": "2.10.0",
-        "@miniflare/shared": "2.10.0",
-        "@miniflare/watcher": "2.10.0",
+        "@miniflare/queues": "2.11.0",
+        "@miniflare/shared": "2.11.0",
+        "@miniflare/watcher": "2.11.0",
         "busboy": "^1.6.0",
         "dotenv": "^10.0.0",
         "kleur": "^4.1.4",
@@ -530,27 +530,27 @@
       }
     },
     "node_modules/@miniflare/d1": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/d1/-/d1-2.10.0.tgz",
-      "integrity": "sha512-mOYZSmpTthH0tmFTQ+O9G0Q+iDAd7oiUtoIBianlKa9QiqYAoO7EBUPy6kUgDHXapOcN5Ri1u3J5UTpxXvw3qg==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/d1/-/d1-2.11.0.tgz",
+      "integrity": "sha512-aDdBVQZ2C0Zs3+Y9ZbRctmuQxozPfpumwJ/6NG6fBadANvune/hW7ddEoxyteIEU9W3IgzVj8s4by4VvasX90A==",
       "dev": true,
       "dependencies": {
-        "@miniflare/core": "2.10.0",
-        "@miniflare/shared": "2.10.0"
+        "@miniflare/core": "2.11.0",
+        "@miniflare/shared": "2.11.0"
       },
       "engines": {
         "node": ">=16.7"
       }
     },
     "node_modules/@miniflare/durable-objects": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.10.0.tgz",
-      "integrity": "sha512-gU45f52gveFtCasm0ixYnt0mHI1lHrPomtmF+89oZGKBzOqUfO5diDs6wmoRSnovOWZCwtmwQGRoorAQN7AmoA==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.11.0.tgz",
+      "integrity": "sha512-0cKJaMgraTEU1b4kqK8cjD2oTeOjA6QU3Y+lWiZT/k1PMHZULovrSFnjii7qZ8npf4VHSIN6XYPxhyxRyEM65Q==",
       "dev": true,
       "dependencies": {
-        "@miniflare/core": "2.10.0",
-        "@miniflare/shared": "2.10.0",
-        "@miniflare/storage-memory": "2.10.0",
+        "@miniflare/core": "2.11.0",
+        "@miniflare/shared": "2.11.0",
+        "@miniflare/storage-memory": "2.11.0",
         "undici": "5.9.1"
       },
       "engines": {
@@ -558,13 +558,13 @@
       }
     },
     "node_modules/@miniflare/html-rewriter": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.10.0.tgz",
-      "integrity": "sha512-hCdG99L8+Ros4dn3B5H37PlQPBH0859EoRslzNTd4jzGIkwdiawpJvrvesL8056GjbUjeJN1zh7OPBRuMgyGLw==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.11.0.tgz",
+      "integrity": "sha512-olTqmuYTHnoTNtiA0vjQ/ixRfbwgPzDrAUbtXDCYW45VFbHfDVJrJGZX3Jg0HpSlxy86Zclle1SUxGbVDzxsBg==",
       "dev": true,
       "dependencies": {
-        "@miniflare/core": "2.10.0",
-        "@miniflare/shared": "2.10.0",
+        "@miniflare/core": "2.11.0",
+        "@miniflare/shared": "2.11.0",
         "html-rewriter-wasm": "^0.4.1",
         "undici": "5.9.1"
       },
@@ -573,14 +573,14 @@
       }
     },
     "node_modules/@miniflare/http-server": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.10.0.tgz",
-      "integrity": "sha512-cm6hwkONucll93yoY8dteMp//Knvmb7n6zAgeHrtuNYKn//lAL6bRY//VLTttrMmfWxZFi1C7WpOeCv8Mn6/ug==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.11.0.tgz",
+      "integrity": "sha512-sMLcrDFzqqAvnQmAUH0hRTo8sBjW79VZYfnIH5FAGSGcKX6kdAGs9RStdYZ4CftQCBAEQScX0KBsMx5FwJRe9Q==",
       "dev": true,
       "dependencies": {
-        "@miniflare/core": "2.10.0",
-        "@miniflare/shared": "2.10.0",
-        "@miniflare/web-sockets": "2.10.0",
+        "@miniflare/core": "2.11.0",
+        "@miniflare/shared": "2.11.0",
+        "@miniflare/web-sockets": "2.11.0",
         "kleur": "^4.1.4",
         "selfsigned": "^2.0.0",
         "undici": "5.9.1",
@@ -592,36 +592,36 @@
       }
     },
     "node_modules/@miniflare/kv": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.10.0.tgz",
-      "integrity": "sha512-3+u1lO77FnlS0lQ6b1VgM1E/ZgQ/zy/FU+SdBG5LUOIiv3x522VYHOApeJLnSEo0KtZUB22Ni0fWQM6DgpaREg==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.11.0.tgz",
+      "integrity": "sha512-3m9dL2HBBN170V1JvwjjucR5zl4G3mlcsV6C1E7A2wLl2Z2TWvIx/tSY9hrhkD96dFnejwJ9qmPMbXMMuynhjg==",
       "dev": true,
       "dependencies": {
-        "@miniflare/shared": "2.10.0"
+        "@miniflare/shared": "2.11.0"
       },
       "engines": {
         "node": ">=16.13"
       }
     },
     "node_modules/@miniflare/queues": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/queues/-/queues-2.10.0.tgz",
-      "integrity": "sha512-WKdO6qI9rfS96KlCjazzPFf+qj6DPov4vONyf18+jzbRjRJh/xwWSk1/1h5A+gDPwVNG8TsNRPh9DW5OKBGNjw==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/queues/-/queues-2.11.0.tgz",
+      "integrity": "sha512-fLHjdrNLKhn0LZM/aii/9GsAttFd+lWlGzK8HOg1R0vhfKBwEub4zntjMmOfFbDm1ntc21tdMK7n3ldUphwh5w==",
       "dev": true,
       "dependencies": {
-        "@miniflare/shared": "2.10.0"
+        "@miniflare/shared": "2.11.0"
       },
       "engines": {
         "node": ">=16.7"
       }
     },
     "node_modules/@miniflare/r2": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/r2/-/r2-2.10.0.tgz",
-      "integrity": "sha512-uC1CCWbwM1t8DdpZgrveg6+CkZLfTq+wUMqs20BC5rCT8u8UyRv6ZVRQ7pTPiswLyt1oYDTXsZJK7tjV0U0zew==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/r2/-/r2-2.11.0.tgz",
+      "integrity": "sha512-MKuyJ/gGNsK3eWbGdygvozqcyaZhM3C6NGHvoaZwH503dwN569j5DpatTWiHGFeDeSu64VqcIsGehz05GDUaag==",
       "dev": true,
       "dependencies": {
-        "@miniflare/shared": "2.10.0",
+        "@miniflare/shared": "2.11.0",
         "undici": "5.9.1"
       },
       "engines": {
@@ -629,25 +629,25 @@
       }
     },
     "node_modules/@miniflare/runner-vm": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.10.0.tgz",
-      "integrity": "sha512-oTsHitQdQ1B1kT3G/6n9AEXsMd/sT1D8tLGzc7Xr79ZrxYxwRO0ATF3cdkxk4dUjUqg/RUqvOJV4YjJGyqvctg==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.11.0.tgz",
+      "integrity": "sha512-bkVSuvCf5+VylqN8lTiLxIYqYcKFbl+BywZGwGQndPC/3wh42J00mM0jw4hRbvXgwuBhlUyCVpEXtYlftFFT/g==",
       "dev": true,
       "dependencies": {
-        "@miniflare/shared": "2.10.0"
+        "@miniflare/shared": "2.11.0"
       },
       "engines": {
         "node": ">=16.13"
       }
     },
     "node_modules/@miniflare/scheduler": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.10.0.tgz",
-      "integrity": "sha512-eGt2cZFE/yo585nT8xINQwdbTotZfeRIh6FUWmZkbva1i5SW0zTiOojr5a95vAGBF3TzwWGsUuzJpLhBB69a/g==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.11.0.tgz",
+      "integrity": "sha512-DPdzINhdWeS99eIicGoluMsD4pLTTAWNQbgCv3CTwgdKA3dxdvMSCkNqZzQLiALzvk9+rSfj46FlH++HE7o7/w==",
       "dev": true,
       "dependencies": {
-        "@miniflare/core": "2.10.0",
-        "@miniflare/shared": "2.10.0",
+        "@miniflare/core": "2.11.0",
+        "@miniflare/shared": "2.11.0",
         "cron-schedule": "^3.0.4"
       },
       "engines": {
@@ -655,9 +655,9 @@
       }
     },
     "node_modules/@miniflare/shared": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.10.0.tgz",
-      "integrity": "sha512-GDSweEhJ3nNtStGm6taZGUNytM0QTQ/sjZSedAKyF1/aHRaZUcD9cuKAMgIbSpKfvgGdLMNS7Bhd8jb249TO7g==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.11.0.tgz",
+      "integrity": "sha512-fWMqq3ZkWAg+k7CnyzMV/rZHugwn+/JxvVzCxrtvxzwotTN547THlOxgZe8JAP23U9BiTxOfpTfnLvFEjAmegw==",
       "dev": true,
       "dependencies": {
         "@types/better-sqlite3": "^7.6.0",
@@ -670,64 +670,64 @@
       }
     },
     "node_modules/@miniflare/sites": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.10.0.tgz",
-      "integrity": "sha512-1NVAT6+JS2OubL+pOOR5E/6MMddxQHWMi/yIDSumyyfXmj7Sm7n5dE1FvNPetggMP4f8+AjoyT9AYvdd1wkspQ==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.11.0.tgz",
+      "integrity": "sha512-qbefKdWZUJgsdLf+kCw03sn3h/92LZgJAbkOpP6bCrfWkXlJ37EQXO4KWdhn4Ghc7A6GwU1s1I/mdB64B3AewQ==",
       "dev": true,
       "dependencies": {
-        "@miniflare/kv": "2.10.0",
-        "@miniflare/shared": "2.10.0",
-        "@miniflare/storage-file": "2.10.0"
+        "@miniflare/kv": "2.11.0",
+        "@miniflare/shared": "2.11.0",
+        "@miniflare/storage-file": "2.11.0"
       },
       "engines": {
         "node": ">=16.13"
       }
     },
     "node_modules/@miniflare/storage-file": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.10.0.tgz",
-      "integrity": "sha512-K/cRIWiTl4+Z+VO6tl4VfuYXA3NLJgvGPV+BCRYD7uTKuPYHqDMErtD1BI1I7nc3WJhwIXfzJrAR3XXhSKKWQQ==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.11.0.tgz",
+      "integrity": "sha512-beWF/lTX74x7AiaSB+xQxywPSNdhtEKvqDkRui8eOJ5kqN2o4UaleLKQGgqmCw3WyHRIsckV7If1qpbNiLtWMw==",
       "dev": true,
       "dependencies": {
-        "@miniflare/shared": "2.10.0",
-        "@miniflare/storage-memory": "2.10.0"
+        "@miniflare/shared": "2.11.0",
+        "@miniflare/storage-memory": "2.11.0"
       },
       "engines": {
         "node": ">=16.13"
       }
     },
     "node_modules/@miniflare/storage-memory": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.10.0.tgz",
-      "integrity": "sha512-ZATU+qZtJ9yG0umgTrOEUi9SU//YyDb8nYXMgqT4JHODYA3RTz1SyyiQSOOz589upJPdu1LN+0j8W24WGRwwxQ==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.11.0.tgz",
+      "integrity": "sha512-s0AhPww7fq/Jz80NbPb+ffhcVRKnfPi7H1dHTRTre2Ud23EVJjAWl2gat42x8NOT/Fu3/o/7A72DWQQJqfO98A==",
       "dev": true,
       "dependencies": {
-        "@miniflare/shared": "2.10.0"
+        "@miniflare/shared": "2.11.0"
       },
       "engines": {
         "node": ">=16.13"
       }
     },
     "node_modules/@miniflare/watcher": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.10.0.tgz",
-      "integrity": "sha512-X9CFYYyszfSYDzs07KhbWC2i08Dpyh3D60fPonYZcoZAfa5h9eATHUdRGvNCdax7awYp4b8bvU8upAI//OPlMg==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.11.0.tgz",
+      "integrity": "sha512-RUfjz2iYcsQXLcGySemJl98CJ2iierbWsPGWZhIVZI+NNhROkEy77g/Q+lvP2ATwexG3/dUSfdJ3P8aH+sI4Ig==",
       "dev": true,
       "dependencies": {
-        "@miniflare/shared": "2.10.0"
+        "@miniflare/shared": "2.11.0"
       },
       "engines": {
         "node": ">=16.13"
       }
     },
     "node_modules/@miniflare/web-sockets": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.10.0.tgz",
-      "integrity": "sha512-W+PrapdQqNEEFeD+amENgPQWcETGDp7OEh6JAoSzCRhHA0OoMe8DG0xb5a5+2FjGW/J7FFKsv84wkURpmFT4dQ==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.11.0.tgz",
+      "integrity": "sha512-NC8RKrmxrO0hZmwpzn5g4hPGA2VblnFTIBobmWoxuK95eW49zfs7dtE/PyFs+blsGv3CjTIjHVSQ782K+C6HFA==",
       "dev": true,
       "dependencies": {
-        "@miniflare/core": "2.10.0",
-        "@miniflare/shared": "2.10.0",
+        "@miniflare/core": "2.11.0",
+        "@miniflare/shared": "2.11.0",
         "undici": "5.9.1",
         "ws": "^8.2.2"
       },
@@ -804,9 +804,9 @@
       }
     },
     "node_modules/@types/better-sqlite3": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.2.tgz",
-      "integrity": "sha512-RgmaapusqTq6IMAr4McMyAsC6RshYTCjXCnzwVV59WctUxC8bNPyUfT9t5F81lKcU41lLurhjqjoMHfauzfqGg==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.3.tgz",
+      "integrity": "sha512-YS64N9SNDT/NAvou3QNdzAu3E2om/W/0dhORimtPGLef+zSK5l1vDzfsWb4xgXOgfhtOI5ZDTRxnvRPb22AIVQ==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
@@ -3058,28 +3058,28 @@
       }
     },
     "node_modules/miniflare": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.10.0.tgz",
-      "integrity": "sha512-WPveqChVDdmDGv+wFqXjFqEZlZ5/aBlAKX37h/e4TAjl2XsK5nPfQATP8jZXwNDEC5iE29bYZymOqeZkp+t7OA==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.11.0.tgz",
+      "integrity": "sha512-QA18I1VQXdCo4nBtPJUcUDxW8c9xbc5ex5F61jwhkGVOISSnYdEheolESmjr8MYk28xwi0XD1ozS4rLaTONd+w==",
       "dev": true,
       "dependencies": {
-        "@miniflare/cache": "2.10.0",
-        "@miniflare/cli-parser": "2.10.0",
-        "@miniflare/core": "2.10.0",
-        "@miniflare/d1": "2.10.0",
-        "@miniflare/durable-objects": "2.10.0",
-        "@miniflare/html-rewriter": "2.10.0",
-        "@miniflare/http-server": "2.10.0",
-        "@miniflare/kv": "2.10.0",
-        "@miniflare/queues": "2.10.0",
-        "@miniflare/r2": "2.10.0",
-        "@miniflare/runner-vm": "2.10.0",
-        "@miniflare/scheduler": "2.10.0",
-        "@miniflare/shared": "2.10.0",
-        "@miniflare/sites": "2.10.0",
-        "@miniflare/storage-file": "2.10.0",
-        "@miniflare/storage-memory": "2.10.0",
-        "@miniflare/web-sockets": "2.10.0",
+        "@miniflare/cache": "2.11.0",
+        "@miniflare/cli-parser": "2.11.0",
+        "@miniflare/core": "2.11.0",
+        "@miniflare/d1": "2.11.0",
+        "@miniflare/durable-objects": "2.11.0",
+        "@miniflare/html-rewriter": "2.11.0",
+        "@miniflare/http-server": "2.11.0",
+        "@miniflare/kv": "2.11.0",
+        "@miniflare/queues": "2.11.0",
+        "@miniflare/r2": "2.11.0",
+        "@miniflare/runner-vm": "2.11.0",
+        "@miniflare/scheduler": "2.11.0",
+        "@miniflare/shared": "2.11.0",
+        "@miniflare/sites": "2.11.0",
+        "@miniflare/storage-file": "2.11.0",
+        "@miniflare/storage-memory": "2.11.0",
+        "@miniflare/web-sockets": "2.11.0",
         "kleur": "^4.1.4",
         "semiver": "^1.1.0",
         "source-map-support": "^0.5.20",
@@ -3092,7 +3092,7 @@
         "node": ">=16.13"
       },
       "peerDependencies": {
-        "@miniflare/storage-redis": "2.10.0",
+        "@miniflare/storage-redis": "2.11.0",
         "cron-schedule": "^3.0.4",
         "ioredis": "^4.27.9"
       },
@@ -4631,21 +4631,21 @@
       }
     },
     "node_modules/wrangler": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-2.6.1.tgz",
-      "integrity": "sha512-v0Kh8KQC33xP82pGXZ+67pJMQIx0CHI+gF2nLIcdZbrB0wAQLQ6lsQYS9UpuTupQg4+RetHToDwk+lzRM0J0cQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-2.8.0.tgz",
+      "integrity": "sha512-CAhjoeTnVFB65HPmOSquXbQ37lc2X77iOirX4tRMuRNKQng2NztHOfo++6BZdlV29E4IPD9boTRXck3R+O8mrg==",
       "dev": true,
       "dependencies": {
         "@cloudflare/kv-asset-handler": "^0.2.0",
         "@esbuild-plugins/node-globals-polyfill": "^0.1.1",
         "@esbuild-plugins/node-modules-polyfill": "^0.1.4",
-        "@miniflare/core": "2.10.0",
-        "@miniflare/d1": "2.10.0",
-        "@miniflare/durable-objects": "2.10.0",
+        "@miniflare/core": "2.11.0",
+        "@miniflare/d1": "2.11.0",
+        "@miniflare/durable-objects": "2.11.0",
         "blake3-wasm": "^2.1.5",
         "chokidar": "^3.5.3",
         "esbuild": "0.14.51",
-        "miniflare": "2.10.0",
+        "miniflare": "2.11.0",
         "nanoid": "^3.3.3",
         "path-to-regexp": "^6.2.0",
         "selfsigned": "^2.0.1",
@@ -4714,16 +4714,16 @@
       "dev": true
     },
     "node_modules/ws": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
-      "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.12.0.tgz",
+      "integrity": "sha512-kU62emKIdKVeEIOIKVegvqpXMSTAMLJozpHZaJNDYqBjzlSYXQGviYwN1osDLJ9av68qHd4a2oSjd7yD4pacig==",
       "dev": true,
       "engines": {
         "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
+        "utf-8-validate": ">=5.0.2"
       },
       "peerDependenciesMeta": {
         "bufferutil": {
@@ -4830,7 +4830,7 @@
     },
     "packages/cloudflare-access": {
       "name": "@cloudflare/pages-plugin-cloudflare-access",
-      "version": "1.0.1"
+      "version": "1.0.2"
     },
     "packages/early-hints": {
       "name": "@cloudflare/pages-plugin-early-hints",
@@ -4838,7 +4838,7 @@
     },
     "packages/google-chat": {
       "name": "@cloudflare/pages-plugin-google-chat",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "dependencies": {
         "jsrsasign": "^10.6.1"
       },
@@ -4849,7 +4849,7 @@
     },
     "packages/graphql": {
       "name": "@cloudflare/pages-plugin-graphql",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "devDependencies": {
         "graphql": "^16.6.0"
       }
@@ -4864,7 +4864,7 @@
     },
     "packages/honeycomb": {
       "name": "@cloudflare/pages-plugin-honeycomb",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "dependencies": {
         "@cloudflare/workers-honeycomb-logger": "^2.3.3"
       }
@@ -4875,7 +4875,7 @@
     },
     "packages/sentry": {
       "name": "@cloudflare/pages-plugin-sentry",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "dependencies": {
         "toucan-js": "^3.0.0"
       }
@@ -5336,37 +5336,37 @@
       }
     },
     "@miniflare/cache": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.10.0.tgz",
-      "integrity": "sha512-nzEqFVPnD7Yf0HMDv7gCPpf4NSXfjhc+zg3gSwUS4Dad5bWV10B1ujTZW6HxQulW3CBHIg616mTjXIiaimVuEQ==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.11.0.tgz",
+      "integrity": "sha512-L/kc9AzidPwFuk2fwHpAEePi0kNBk6FWUq3ln+9beRCDrPEpfVrDRFpNleF1NFZz5//oeVMuo8F0IVUQGzR7+Q==",
       "dev": true,
       "requires": {
-        "@miniflare/core": "2.10.0",
-        "@miniflare/shared": "2.10.0",
+        "@miniflare/core": "2.11.0",
+        "@miniflare/shared": "2.11.0",
         "http-cache-semantics": "^4.1.0",
         "undici": "5.9.1"
       }
     },
     "@miniflare/cli-parser": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.10.0.tgz",
-      "integrity": "sha512-NAiCtqlHTUKCmV+Jl9af+ixGmMhiGhIyIfr/vCdbismNEBxEsrQGg3sQYTNfvCkdHtODurQqayQreFq21OuEow==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.11.0.tgz",
+      "integrity": "sha512-JUmyRzEGAS6CouvXJwBh8p44onfw3KRpfq5JGXEuHModOGjTp6li7PQyCTNPV2Hv/7StAXWnTFGXeAqyDHuTig==",
       "dev": true,
       "requires": {
-        "@miniflare/shared": "2.10.0",
+        "@miniflare/shared": "2.11.0",
         "kleur": "^4.1.4"
       }
     },
     "@miniflare/core": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.10.0.tgz",
-      "integrity": "sha512-Jx1M5oXQua0jzsJVdZSq07baVRmGC/6JkglrPQGAlZ7gQ1sunVZzq9fjxFqj0bqfEuYS0Wy6+lvK4rOAHISIjw==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.11.0.tgz",
+      "integrity": "sha512-UFMFiCG0co36VpZkgFrSBnrxo71uf1x+cjlzzJi3khmMyDlnLu4RuIQsAqvKbYom6fi3G9Q8lTgM7JuOXFyjhw==",
       "dev": true,
       "requires": {
         "@iarna/toml": "^2.2.5",
-        "@miniflare/queues": "2.10.0",
-        "@miniflare/shared": "2.10.0",
-        "@miniflare/watcher": "2.10.0",
+        "@miniflare/queues": "2.11.0",
+        "@miniflare/shared": "2.11.0",
+        "@miniflare/watcher": "2.11.0",
         "busboy": "^1.6.0",
         "dotenv": "^10.0.0",
         "kleur": "^4.1.4",
@@ -5376,48 +5376,48 @@
       }
     },
     "@miniflare/d1": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/d1/-/d1-2.10.0.tgz",
-      "integrity": "sha512-mOYZSmpTthH0tmFTQ+O9G0Q+iDAd7oiUtoIBianlKa9QiqYAoO7EBUPy6kUgDHXapOcN5Ri1u3J5UTpxXvw3qg==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/d1/-/d1-2.11.0.tgz",
+      "integrity": "sha512-aDdBVQZ2C0Zs3+Y9ZbRctmuQxozPfpumwJ/6NG6fBadANvune/hW7ddEoxyteIEU9W3IgzVj8s4by4VvasX90A==",
       "dev": true,
       "requires": {
-        "@miniflare/core": "2.10.0",
-        "@miniflare/shared": "2.10.0"
+        "@miniflare/core": "2.11.0",
+        "@miniflare/shared": "2.11.0"
       }
     },
     "@miniflare/durable-objects": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.10.0.tgz",
-      "integrity": "sha512-gU45f52gveFtCasm0ixYnt0mHI1lHrPomtmF+89oZGKBzOqUfO5diDs6wmoRSnovOWZCwtmwQGRoorAQN7AmoA==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.11.0.tgz",
+      "integrity": "sha512-0cKJaMgraTEU1b4kqK8cjD2oTeOjA6QU3Y+lWiZT/k1PMHZULovrSFnjii7qZ8npf4VHSIN6XYPxhyxRyEM65Q==",
       "dev": true,
       "requires": {
-        "@miniflare/core": "2.10.0",
-        "@miniflare/shared": "2.10.0",
-        "@miniflare/storage-memory": "2.10.0",
+        "@miniflare/core": "2.11.0",
+        "@miniflare/shared": "2.11.0",
+        "@miniflare/storage-memory": "2.11.0",
         "undici": "5.9.1"
       }
     },
     "@miniflare/html-rewriter": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.10.0.tgz",
-      "integrity": "sha512-hCdG99L8+Ros4dn3B5H37PlQPBH0859EoRslzNTd4jzGIkwdiawpJvrvesL8056GjbUjeJN1zh7OPBRuMgyGLw==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.11.0.tgz",
+      "integrity": "sha512-olTqmuYTHnoTNtiA0vjQ/ixRfbwgPzDrAUbtXDCYW45VFbHfDVJrJGZX3Jg0HpSlxy86Zclle1SUxGbVDzxsBg==",
       "dev": true,
       "requires": {
-        "@miniflare/core": "2.10.0",
-        "@miniflare/shared": "2.10.0",
+        "@miniflare/core": "2.11.0",
+        "@miniflare/shared": "2.11.0",
         "html-rewriter-wasm": "^0.4.1",
         "undici": "5.9.1"
       }
     },
     "@miniflare/http-server": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.10.0.tgz",
-      "integrity": "sha512-cm6hwkONucll93yoY8dteMp//Knvmb7n6zAgeHrtuNYKn//lAL6bRY//VLTttrMmfWxZFi1C7WpOeCv8Mn6/ug==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.11.0.tgz",
+      "integrity": "sha512-sMLcrDFzqqAvnQmAUH0hRTo8sBjW79VZYfnIH5FAGSGcKX6kdAGs9RStdYZ4CftQCBAEQScX0KBsMx5FwJRe9Q==",
       "dev": true,
       "requires": {
-        "@miniflare/core": "2.10.0",
-        "@miniflare/shared": "2.10.0",
-        "@miniflare/web-sockets": "2.10.0",
+        "@miniflare/core": "2.11.0",
+        "@miniflare/shared": "2.11.0",
+        "@miniflare/web-sockets": "2.11.0",
         "kleur": "^4.1.4",
         "selfsigned": "^2.0.0",
         "undici": "5.9.1",
@@ -5426,57 +5426,57 @@
       }
     },
     "@miniflare/kv": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.10.0.tgz",
-      "integrity": "sha512-3+u1lO77FnlS0lQ6b1VgM1E/ZgQ/zy/FU+SdBG5LUOIiv3x522VYHOApeJLnSEo0KtZUB22Ni0fWQM6DgpaREg==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.11.0.tgz",
+      "integrity": "sha512-3m9dL2HBBN170V1JvwjjucR5zl4G3mlcsV6C1E7A2wLl2Z2TWvIx/tSY9hrhkD96dFnejwJ9qmPMbXMMuynhjg==",
       "dev": true,
       "requires": {
-        "@miniflare/shared": "2.10.0"
+        "@miniflare/shared": "2.11.0"
       }
     },
     "@miniflare/queues": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/queues/-/queues-2.10.0.tgz",
-      "integrity": "sha512-WKdO6qI9rfS96KlCjazzPFf+qj6DPov4vONyf18+jzbRjRJh/xwWSk1/1h5A+gDPwVNG8TsNRPh9DW5OKBGNjw==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/queues/-/queues-2.11.0.tgz",
+      "integrity": "sha512-fLHjdrNLKhn0LZM/aii/9GsAttFd+lWlGzK8HOg1R0vhfKBwEub4zntjMmOfFbDm1ntc21tdMK7n3ldUphwh5w==",
       "dev": true,
       "requires": {
-        "@miniflare/shared": "2.10.0"
+        "@miniflare/shared": "2.11.0"
       }
     },
     "@miniflare/r2": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/r2/-/r2-2.10.0.tgz",
-      "integrity": "sha512-uC1CCWbwM1t8DdpZgrveg6+CkZLfTq+wUMqs20BC5rCT8u8UyRv6ZVRQ7pTPiswLyt1oYDTXsZJK7tjV0U0zew==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/r2/-/r2-2.11.0.tgz",
+      "integrity": "sha512-MKuyJ/gGNsK3eWbGdygvozqcyaZhM3C6NGHvoaZwH503dwN569j5DpatTWiHGFeDeSu64VqcIsGehz05GDUaag==",
       "dev": true,
       "requires": {
-        "@miniflare/shared": "2.10.0",
+        "@miniflare/shared": "2.11.0",
         "undici": "5.9.1"
       }
     },
     "@miniflare/runner-vm": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.10.0.tgz",
-      "integrity": "sha512-oTsHitQdQ1B1kT3G/6n9AEXsMd/sT1D8tLGzc7Xr79ZrxYxwRO0ATF3cdkxk4dUjUqg/RUqvOJV4YjJGyqvctg==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.11.0.tgz",
+      "integrity": "sha512-bkVSuvCf5+VylqN8lTiLxIYqYcKFbl+BywZGwGQndPC/3wh42J00mM0jw4hRbvXgwuBhlUyCVpEXtYlftFFT/g==",
       "dev": true,
       "requires": {
-        "@miniflare/shared": "2.10.0"
+        "@miniflare/shared": "2.11.0"
       }
     },
     "@miniflare/scheduler": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.10.0.tgz",
-      "integrity": "sha512-eGt2cZFE/yo585nT8xINQwdbTotZfeRIh6FUWmZkbva1i5SW0zTiOojr5a95vAGBF3TzwWGsUuzJpLhBB69a/g==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.11.0.tgz",
+      "integrity": "sha512-DPdzINhdWeS99eIicGoluMsD4pLTTAWNQbgCv3CTwgdKA3dxdvMSCkNqZzQLiALzvk9+rSfj46FlH++HE7o7/w==",
       "dev": true,
       "requires": {
-        "@miniflare/core": "2.10.0",
-        "@miniflare/shared": "2.10.0",
+        "@miniflare/core": "2.11.0",
+        "@miniflare/shared": "2.11.0",
         "cron-schedule": "^3.0.4"
       }
     },
     "@miniflare/shared": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.10.0.tgz",
-      "integrity": "sha512-GDSweEhJ3nNtStGm6taZGUNytM0QTQ/sjZSedAKyF1/aHRaZUcD9cuKAMgIbSpKfvgGdLMNS7Bhd8jb249TO7g==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.11.0.tgz",
+      "integrity": "sha512-fWMqq3ZkWAg+k7CnyzMV/rZHugwn+/JxvVzCxrtvxzwotTN547THlOxgZe8JAP23U9BiTxOfpTfnLvFEjAmegw==",
       "dev": true,
       "requires": {
         "@types/better-sqlite3": "^7.6.0",
@@ -5486,52 +5486,52 @@
       }
     },
     "@miniflare/sites": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.10.0.tgz",
-      "integrity": "sha512-1NVAT6+JS2OubL+pOOR5E/6MMddxQHWMi/yIDSumyyfXmj7Sm7n5dE1FvNPetggMP4f8+AjoyT9AYvdd1wkspQ==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.11.0.tgz",
+      "integrity": "sha512-qbefKdWZUJgsdLf+kCw03sn3h/92LZgJAbkOpP6bCrfWkXlJ37EQXO4KWdhn4Ghc7A6GwU1s1I/mdB64B3AewQ==",
       "dev": true,
       "requires": {
-        "@miniflare/kv": "2.10.0",
-        "@miniflare/shared": "2.10.0",
-        "@miniflare/storage-file": "2.10.0"
+        "@miniflare/kv": "2.11.0",
+        "@miniflare/shared": "2.11.0",
+        "@miniflare/storage-file": "2.11.0"
       }
     },
     "@miniflare/storage-file": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.10.0.tgz",
-      "integrity": "sha512-K/cRIWiTl4+Z+VO6tl4VfuYXA3NLJgvGPV+BCRYD7uTKuPYHqDMErtD1BI1I7nc3WJhwIXfzJrAR3XXhSKKWQQ==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.11.0.tgz",
+      "integrity": "sha512-beWF/lTX74x7AiaSB+xQxywPSNdhtEKvqDkRui8eOJ5kqN2o4UaleLKQGgqmCw3WyHRIsckV7If1qpbNiLtWMw==",
       "dev": true,
       "requires": {
-        "@miniflare/shared": "2.10.0",
-        "@miniflare/storage-memory": "2.10.0"
+        "@miniflare/shared": "2.11.0",
+        "@miniflare/storage-memory": "2.11.0"
       }
     },
     "@miniflare/storage-memory": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.10.0.tgz",
-      "integrity": "sha512-ZATU+qZtJ9yG0umgTrOEUi9SU//YyDb8nYXMgqT4JHODYA3RTz1SyyiQSOOz589upJPdu1LN+0j8W24WGRwwxQ==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.11.0.tgz",
+      "integrity": "sha512-s0AhPww7fq/Jz80NbPb+ffhcVRKnfPi7H1dHTRTre2Ud23EVJjAWl2gat42x8NOT/Fu3/o/7A72DWQQJqfO98A==",
       "dev": true,
       "requires": {
-        "@miniflare/shared": "2.10.0"
+        "@miniflare/shared": "2.11.0"
       }
     },
     "@miniflare/watcher": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.10.0.tgz",
-      "integrity": "sha512-X9CFYYyszfSYDzs07KhbWC2i08Dpyh3D60fPonYZcoZAfa5h9eATHUdRGvNCdax7awYp4b8bvU8upAI//OPlMg==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.11.0.tgz",
+      "integrity": "sha512-RUfjz2iYcsQXLcGySemJl98CJ2iierbWsPGWZhIVZI+NNhROkEy77g/Q+lvP2ATwexG3/dUSfdJ3P8aH+sI4Ig==",
       "dev": true,
       "requires": {
-        "@miniflare/shared": "2.10.0"
+        "@miniflare/shared": "2.11.0"
       }
     },
     "@miniflare/web-sockets": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.10.0.tgz",
-      "integrity": "sha512-W+PrapdQqNEEFeD+amENgPQWcETGDp7OEh6JAoSzCRhHA0OoMe8DG0xb5a5+2FjGW/J7FFKsv84wkURpmFT4dQ==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.11.0.tgz",
+      "integrity": "sha512-NC8RKrmxrO0hZmwpzn5g4hPGA2VblnFTIBobmWoxuK95eW49zfs7dtE/PyFs+blsGv3CjTIjHVSQ782K+C6HFA==",
       "dev": true,
       "requires": {
-        "@miniflare/core": "2.10.0",
-        "@miniflare/shared": "2.10.0",
+        "@miniflare/core": "2.11.0",
+        "@miniflare/shared": "2.11.0",
         "undici": "5.9.1",
         "ws": "^8.2.2"
       }
@@ -5587,9 +5587,9 @@
       }
     },
     "@types/better-sqlite3": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.2.tgz",
-      "integrity": "sha512-RgmaapusqTq6IMAr4McMyAsC6RshYTCjXCnzwVV59WctUxC8bNPyUfT9t5F81lKcU41lLurhjqjoMHfauzfqGg==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.3.tgz",
+      "integrity": "sha512-YS64N9SNDT/NAvou3QNdzAu3E2om/W/0dhORimtPGLef+zSK5l1vDzfsWb4xgXOgfhtOI5ZDTRxnvRPb22AIVQ==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -7184,28 +7184,28 @@
       "dev": true
     },
     "miniflare": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.10.0.tgz",
-      "integrity": "sha512-WPveqChVDdmDGv+wFqXjFqEZlZ5/aBlAKX37h/e4TAjl2XsK5nPfQATP8jZXwNDEC5iE29bYZymOqeZkp+t7OA==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.11.0.tgz",
+      "integrity": "sha512-QA18I1VQXdCo4nBtPJUcUDxW8c9xbc5ex5F61jwhkGVOISSnYdEheolESmjr8MYk28xwi0XD1ozS4rLaTONd+w==",
       "dev": true,
       "requires": {
-        "@miniflare/cache": "2.10.0",
-        "@miniflare/cli-parser": "2.10.0",
-        "@miniflare/core": "2.10.0",
-        "@miniflare/d1": "2.10.0",
-        "@miniflare/durable-objects": "2.10.0",
-        "@miniflare/html-rewriter": "2.10.0",
-        "@miniflare/http-server": "2.10.0",
-        "@miniflare/kv": "2.10.0",
-        "@miniflare/queues": "2.10.0",
-        "@miniflare/r2": "2.10.0",
-        "@miniflare/runner-vm": "2.10.0",
-        "@miniflare/scheduler": "2.10.0",
-        "@miniflare/shared": "2.10.0",
-        "@miniflare/sites": "2.10.0",
-        "@miniflare/storage-file": "2.10.0",
-        "@miniflare/storage-memory": "2.10.0",
-        "@miniflare/web-sockets": "2.10.0",
+        "@miniflare/cache": "2.11.0",
+        "@miniflare/cli-parser": "2.11.0",
+        "@miniflare/core": "2.11.0",
+        "@miniflare/d1": "2.11.0",
+        "@miniflare/durable-objects": "2.11.0",
+        "@miniflare/html-rewriter": "2.11.0",
+        "@miniflare/http-server": "2.11.0",
+        "@miniflare/kv": "2.11.0",
+        "@miniflare/queues": "2.11.0",
+        "@miniflare/r2": "2.11.0",
+        "@miniflare/runner-vm": "2.11.0",
+        "@miniflare/scheduler": "2.11.0",
+        "@miniflare/shared": "2.11.0",
+        "@miniflare/sites": "2.11.0",
+        "@miniflare/storage-file": "2.11.0",
+        "@miniflare/storage-memory": "2.11.0",
+        "@miniflare/web-sockets": "2.11.0",
         "kleur": "^4.1.4",
         "semiver": "^1.1.0",
         "source-map-support": "^0.5.20",
@@ -8334,22 +8334,22 @@
       }
     },
     "wrangler": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-2.6.1.tgz",
-      "integrity": "sha512-v0Kh8KQC33xP82pGXZ+67pJMQIx0CHI+gF2nLIcdZbrB0wAQLQ6lsQYS9UpuTupQg4+RetHToDwk+lzRM0J0cQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-2.8.0.tgz",
+      "integrity": "sha512-CAhjoeTnVFB65HPmOSquXbQ37lc2X77iOirX4tRMuRNKQng2NztHOfo++6BZdlV29E4IPD9boTRXck3R+O8mrg==",
       "dev": true,
       "requires": {
         "@cloudflare/kv-asset-handler": "^0.2.0",
         "@esbuild-plugins/node-globals-polyfill": "^0.1.1",
         "@esbuild-plugins/node-modules-polyfill": "^0.1.4",
-        "@miniflare/core": "2.10.0",
-        "@miniflare/d1": "2.10.0",
-        "@miniflare/durable-objects": "2.10.0",
+        "@miniflare/core": "2.11.0",
+        "@miniflare/d1": "2.11.0",
+        "@miniflare/durable-objects": "2.11.0",
         "blake3-wasm": "^2.1.5",
         "chokidar": "^3.5.3",
         "esbuild": "0.14.51",
         "fsevents": "~2.3.2",
-        "miniflare": "2.10.0",
+        "miniflare": "2.11.0",
         "nanoid": "^3.3.3",
         "path-to-regexp": "^6.2.0",
         "selfsigned": "^2.0.1",
@@ -8395,9 +8395,9 @@
       }
     },
     "ws": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
-      "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.12.0.tgz",
+      "integrity": "sha512-kU62emKIdKVeEIOIKVegvqpXMSTAMLJozpHZaJNDYqBjzlSYXQGviYwN1osDLJ9av68qHd4a2oSjd7yD4pacig==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -17,6 +17,6 @@
     "@changesets/cli": "^2.25.2",
     "@cloudflare/workers-types": "^4.20221111.1",
     "typescript": "^4.9.3",
-    "wrangler": "^2.6.1"
+    "wrangler": "^2.8.0"
   }
 }


### PR DESCRIPTION
There was a [bug in Wrangler](https://github.com/cloudflare/wrangler2/issues/2568), fixed in v2.7.0, that caused plugins compiled with `npx wrangler pages functions build --plugin --outfile index.js` to always return a 200. This PR upgrades Wrangler to v2.8.0.

I've tested that this fixes my issues with the Honeycomb plugin. I suspect it's also going to fix #14 and #21.