### PR TITLE
fix link early hint to docs

### DIFF
--- a/packages/early-hints/README.md
+++ b/packages/early-hints/README.md
@@ -10,4 +10,4 @@ npm install --save @cloudflare/pages-plugin-early-hints
 
 ## Usage
 
-Documentation available on [Cloudflare's Developer Docs](https://developers.cloudflare.com/pages/platform/functions/plugins/early-hints/).
+Documentation available on [Cloudflare's Developer Docs](https://developers.cloudflare.com/pages/platform/early-hints/).


### PR DESCRIPTION
correct link is https://developers.cloudflare.com/pages/platform/early-hints/