### PR TITLE
fix pages-plugin-sentry types

### DIFF
--- a/.changeset/olive-onions-dress.md
+++ b/.changeset/olive-onions-dress.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/pages-plugin-sentry": patch
+---
+
+fix: Correctly type the PluginData (`context.data.sentry`) as a Toucan instance

--- a/packages/sentry/index.d.ts
+++ b/packages/sentry/index.d.ts
@@ -1,4 +1,4 @@
-import type Toucan from "toucan-js";
+import type { Toucan } from "toucan-js";
 import type { Options } from "toucan-js/dist/types";
 
 export type PluginArgs = Omit<Options, "context">;


### PR DESCRIPTION
Should fix `Cannot use namespace 'Toucan' as a type.`.

```
node_modules/@cloudflare/pages-plugin-sentry/index.d.ts:6:36 - error TS2709: Cannot use namespace 'Toucan' as a type.

6 export type PluginData = { sentry: Toucan };
                                     ~~~~~~


Found 1 error in node_modules/@cloudflare/pages-plugin-sentry/index.d.ts:6
```