### PR TITLE
feat(mailchannels): show errors

### DIFF
--- a/.changeset/mean-ears-pull.md
+++ b/.changeset/mean-ears-pull.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/pages-plugin-mailchannels": minor
+---
+
+Give insight into why the api request failed.

--- a/packages/mailchannels/functions/_middleware.ts
+++ b/packages/mailchannels/functions/_middleware.ts
@@ -81,17 +81,18 @@ export const onRequest: MailChannelsPagesPluginFunction = async (context) => {
             },
           ];
 
-      const { success } = await sendEmail({
+      const { success, errors } = await sendEmail({
         personalizations,
         from,
         subject,
         content,
       });
+
       if (success) {
         return pluginArgs.respondWith(submission);
       }
 
-      return new Response(`Could not send your email. Please try again.`, {
+      return new Response(`Could not send your email: ${errors.join(', ')}`, {
         status: 512,
       });
     },


### PR DESCRIPTION
Gives insight into why the api request failed.

cc @GregBrimble 