### PR TITLE
Deprecate Sentry plugin in favor of official Sentry one

### DIFF
--- a/.changeset/three-elephants-carry.md
+++ b/.changeset/three-elephants-carry.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/pages-plugin-sentry": patch
+---
+
+chore: Deprecate @cloudflare/pages-plugin-sentry in favor of official Sentry plugin instead

--- a/packages/sentry/README.md
+++ b/packages/sentry/README.md
@@ -1,3 +1,5 @@
+_Sentry now provides official support for Cloudflare Workers and Pages. Refer to the [Sentry documentation](https://docs.sentry.io/platforms/javascript/guides/cloudflare/) for more details._
+
 ## Pages Plugins
 
 # Sentry Pages Plugin


### PR DESCRIPTION
https://github.com/cloudflare/cloudflare-docs/pull/17005

Need to run npm deprecate after releasing.